### PR TITLE
Use url argument instead of path to json file

### DIFF
--- a/app/async.js
+++ b/app/async.js
@@ -13,7 +13,7 @@ define([ 'jquery' ], function($) {
     manipulateRemoteData : function(url) {
       var dfd = $.Deferred();
 
-      $.ajax('/data/testdata.json').then(function(resp) {
+      $.ajax(url).then(function(resp) {
         var people = $.map(resp.people, function(person) {
           return person.name;
         });


### PR DESCRIPTION
I gotta say, this one test case was a bit trickier than the rest :) I'd personally go with the regular JavaScript array `resp.map` rather than the jQuery version, but that's more of a personal preference thing.

Thanks for putting these assessment test cases together, it'll be really useful.
