### PR TITLE
Missing comma

### DIFF
--- a/app/regex.js
+++ b/app/regex.js
@@ -24,7 +24,7 @@ define(function() {
 
     matchesPattern : function(str) {
       return !!str.match(/^\d{3}-\d{3}-\d{4}$/);
-    }
+    },
 
     isUSD : function(str) {
       return /^\$\d{1,3}(,\d{3})*(\.\d{2})?$/.test(str);


### PR DESCRIPTION
Add a missing comma in the regex.js file, since all regex tests were failing without it.
