### PR TITLE
Checks for typeof number

### DIFF
--- a/app/flowControl.js
+++ b/app/flowControl.js
@@ -12,25 +12,20 @@ define(function() {
       // otherwise the function should return the number, or false if no number
       // was provided
 
-      if (!num) { return false; }
+      // empty string to contain potential responses
+      var fb = '';
 
-      // not divisible by 3 or 5
-      if (num % 3 && num % 5) {
-        return num;
-      }
+      // NaN
+      if (typeof num !== 'number') { return false; }
 
-      // divisible by 3 but not 5
-      if (num % 5) {
-        return 'fizz';
-      }
+      // if divisible by 3, add fizz
+      if (num % 3 === 0)  { fb += 'fizz'; }
 
-      // divisible by 5 but not 3
-      if (num % 3) {
-        return 'buzz';
-      }
+      // if divisible by 5, add buzz
+      if (num % 5 === 0) { fb += 'buzz'; }
 
-      // divisible by 5 and 3
-      return 'fizzbuzz';
+      // return fizzbuzz string if has length or the number
+      return fb || num;
     }
   };
 });


### PR DESCRIPTION
I also adjusted the flow slightly. It doesn't check for modulus of 3 and 5 twice. I tried to avoid getting too cute (banging the output of the modulus instead of comparing it to 0) yet still do things javascript-y (checking for the truthiness of the string at the bottom in the return). I also tried to be consistent with established style but if I missed something, I would be happy to adjust.

One thing I wanted to ask about, I considered going all Postel and attempting to parse the passed in number in case it was a string or something. However, I ended up thinking if I did that in real code that could actually hide an issue in my invocation. Felt like that made it a bit of an anti-pattern but I'm absolutely open to adjust the answer (and adding additional tests) to handle that.
