### PR TITLE
changing timeout to 100 milliseconds to match the test expectation

### DIFF
--- a/app/count.js
+++ b/app/count.js
@@ -8,7 +8,7 @@ define(function () {
         console.log(start++);
 
         if (start <= end) {
-          timeout = setTimeout(doIt, 1000);
+          timeout = setTimeout(doIt, 100);
         }
       }
 


### PR DESCRIPTION
[The test for this answer](https://github.com/rmurphey/js-assessment/blob/master/tests/app/count.js) states that the timeout should be set to 1/10th of a second. The answer currently sets the timeout to 1000 milliseconds when it should be 100.