### PR TITLE
Improved some solutions

### DIFF
--- a/app/flowControl.js
+++ b/app/flowControl.js
@@ -13,23 +13,8 @@ define(function() {
       // was provided or if the value provided was not a number
       if (typeof num !== 'number') { return false; }
 
-      // not divisible by 3 or 5
-      if (num % 3 && num % 5) {
-        return num;
-      }
-
-      // divisible by 3 but not 5
-      if (num % 5) {
-        return 'fizz';
-      }
-
-      // divisible by 5 but not 3
-      if (num % 3) {
-        return 'buzz';
-      }
-
-      // divisible by 5 and 3
-      return 'fizzbuzz';
+      var a = ["fizz", "", "", "", "", "buzz"];
+      return a[num % 3] + a[5 - num % 5] || num;
     }
   };
 });

--- a/app/functions.js
+++ b/app/functions.js
@@ -59,26 +59,16 @@ define(function() {
       };
     },
 
-    curryIt : function(fn) {
-      function applyArguments(fn, arguments) {
-        return fn.apply(null, arguments);
-      }
-
-      function getArgumentAccumulator(accumulatedArguments, expectedArgumentsCount) {
-        return function (currentArgument) {
-          accumulatedArguments.push(currentArgument);
-
-          var allArgumentsProvided = accumulatedArguments.length === expectedArgumentsCount;
-
-          if (allArgumentsProvided) {
-            return applyArguments(fn, accumulatedArguments);
-          } else {
-            return getArgumentAccumulator(accumulatedArguments, expectedArgumentsCount);
-          }
+    curryIt: function curryIt(fn) {
+      var args = Array.prototype.slice.call(arguments, 1);
+      if (args.length >= fn.length) {
+        return fn.apply(null, args);
+      } else {
+        args.splice(0, 0, fn);
+        return function() {
+          return curryIt.apply(null, Array.prototype.concat.apply(args, arguments));
         };
       }
-
-      return getArgumentAccumulator([], fn.length);
     }
   };
 });

--- a/app/functions.js
+++ b/app/functions.js
@@ -69,6 +69,29 @@ define(function() {
           return curryIt.apply(null, Array.prototype.concat.apply(args, arguments));
         };
       }
+    },
+    
+    memoizeIt: function(fn) {
+      
+      var memoize = function() {
+        var key = '';
+        for (var i = 0; i < arguments.length; i++) {
+          if (key !== '') {
+            key += " ";
+          }
+          key += arguments[i];
+        }
+        
+        if (!memoize.cache[key]) {
+          memoize.cache[key] = fn.apply(null, arguments);
+        }
+        
+        return memoize.cache[key];
+      }
+      
+      memoize.cache = {};
+      
+      return memoize;
     }
   };
 });

--- a/app/inheritance.js
+++ b/app/inheritance.js
@@ -1,0 +1,28 @@
+if (typeof define !== 'function') {
+  var define = require('amdefine')(module);
+}
+
+define(function() {
+  return {
+    deepExtend: function deepExtend(destination, source) {
+      for (var property in source) {
+        if (source[property] && source[property].constructor &&
+          source[property].constructor === Object) {
+          destination[property] = {};
+          deepExtend(destination[property], source[property]);
+        } else {
+          destination[property] = source[property];
+        }
+      }
+      return destination;
+    },
+    
+    inherits: function (Child, Parent) {
+      function F() {}
+      F.prototype = Parent.prototype;
+      Child.prototype = new F();
+      F.prototype.__super__ = Parent.prototype;
+      Child.prototype.constructor = Child;
+    }
+  };
+});

--- a/app/recursion.js
+++ b/app/recursion.js
@@ -32,48 +32,20 @@ define(function() {
     },
 
     permute: function(arr) {
-      // http://stackoverflow.com/a/11509565/54468
-      var temp = [];
-      var answer = [];
-
-      return doIt(arr);
-
-      function doIt(a) {
-        var i, len, item;
-
-        for (i = 0, len = arr.length; i < len; i++) {
-          // remove the item at index i
-          item = arr.splice(i, 1)[0];
-
-          // add that item to the array we're building up
-          temp.push(item);
-
-          if (arr.length) {
-            // if there's still anything left in the array,
-            // recurse over what's left
-            doIt(arr);
-          } else {
-            // otherwise, log the result and move on
-            logResult();
+      function permute(arr, pre, results) {
+        if (arr.length < 2) {
+          results.push(pre.concat(arr));          
+        } else {
+          for (var i = 0; i < arr.length; i++) {
+            var clone = arr.slice(0);
+            var item = clone.splice(i, 1);
+            permute(clone, pre.concat(item), results);
           }
-
-          // restore the item we removed at index i
-          // and remove it from our temp array
-          arr.splice(i, 0, item);
-          temp.pop();
         }
+        return results;
 
-        return answer;
       }
-
-      function logResult() {
-        answer.push(
-          // make a copy of temp using .slice()
-          // so we can continue to work with temp
-          temp.slice()
-        );
-      }
+      return permute(arr, [], []);
     }
   };
 });
-


### PR DESCRIPTION
### curryIt solution: 
Now, when you call the function, it could take a variable number of arguments. Thus it is not necessary to pass the arguments one by one.

A valid test for the solution might be:

```js
    it('you should be able to curry existing functions', function() {
      var curryMe = function(x, y, z) {
        return x / y * z;
      };

      var a = Math.random(), b = Math.random(), c = Math.random(), result;

      result = answers.curryIt(curryMe);
      expect(typeof result).to.eql('function');

      result = answers.curryIt(curryMe)(a);
      expect(typeof result).to.eql('function');

      result = answers.curryIt(curryMe)(a)(b);
      expect(typeof result).to.eql('function');

      result = answers.curryIt(curryMe)(a)(b)(c);
      expect(typeof result).to.eql('number');
      expect(result).to.eql(curryMe(a, b, c));

      result = answers.curryIt(curryMe, a)(b, c);
      expect(typeof result).to.eql('number');
      expect(result).to.eql(curryMe(a, b, c));

      result = answers.curryIt(curryMe, a, b, c);
      expect(typeof result).to.eql('number');
      expect(result).to.eql(curryMe(a, b, c));

      result = answers.curryIt(curryMe, a, b)(c);
      expect(typeof result).to.eql('number');
      expect(result).to.eql(curryMe(a, b, c));

      result = answers.curryIt(curryMe)(a, b, c);
      expect(typeof result).to.eql('number');
      expect(result).to.eql(curryMe(a, b, c));

      result = answers.curryIt(curryMe)()()(a, b, c);
      expect(typeof result).to.eql('number');
      expect(result).to.eql(curryMe(a, b, c));
    });
```