### PR TITLE
Faster duplicate finder

### DIFF
--- a/app/arrays.js
+++ b/app/arrays.js
@@ -98,7 +98,7 @@ define(function() {
 
           for (var i = 0, len = arr.length; i < len; i++) {
               var val = arr[i];
-              if(arr.indexOf(val) !== arr.lastIndexOf(val) && dupes.indexOf(val) === -1){
+              if(dupes.indexOf(val) === -1 && arr.indexOf(val) !== arr.lastIndexOf(val)){
                   dupes.push(val);
               }
           }

--- a/app/arrays.js
+++ b/app/arrays.js
@@ -104,7 +104,7 @@ define(function() {
         }
 
         return dupes;
-      },
+    },
 
     square : function(arr) {
       var ret = [];

--- a/app/arrays.js
+++ b/app/arrays.js
@@ -93,22 +93,18 @@ define(function() {
       return count;
     },
 
-    duplicates : function(arr) {
-      var seen = {};
-      var dupes = [];
+      duplicates : function(arr) {
+          var dupes = [];
 
-      for (var i = 0, len = arr.length; i < len; i++) {
-        seen[arr[i]] = seen[arr[i]] ? seen[arr[i]] + 1 : 1;
-      }
+          for (var i = 0, len = arr.length; i < len; i++) {
+              var val = arr[i];
+              if(arr.indexOf(val) !== arr.lastIndexOf(val) && dupes.indexOf(val) === -1){
+                  dupes.push(val);
+              }
+          }
 
-      for (var item in seen) {
-        if (seen.hasOwnProperty(item) && seen[item] > 1) {
-          dupes.push(item);
-        }
-      }
-
-      return dupes;
-    },
+          return dupes;
+      },
 
     square : function(arr) {
       var ret = [];

--- a/app/arrays.js
+++ b/app/arrays.js
@@ -93,17 +93,17 @@ define(function() {
       return count;
     },
 
-      duplicates : function(arr) {
-          var dupes = [];
+    duplicates : function(arr) {
+        var dupes = [];
 
-          for (var i = 0, len = arr.length; i < len; i++) {
-              var val = arr[i];
-              if(dupes.indexOf(val) === -1 && arr.indexOf(val) !== arr.lastIndexOf(val)){
-                  dupes.push(val);
-              }
-          }
+        for (var i = 0, len = arr.length; i < len; i++) {
+            var val = arr[i];
+            if(dupes.indexOf(val) === -1 && arr.indexOf(val) !== arr.lastIndexOf(val)){
+                dupes.push(val);
+            }
+        }
 
-          return dupes;
+        return dupes;
       },
 
     square : function(arr) {


### PR DESCRIPTION
Instead of needing to check an object for a calculated occurrence count we can check if the first index matches the last index of a given value. Though I suppose there could be a cross browser issue here as lastIndexOf isn't supported by IE 8 and below. Maybe lastIndexOf could be another test function if that's a concern :-p

When I first saw the current answer I expected it to be faster given the number of times the proposed change set calls indexOf. [Ran a JSPerf test](http://jsperf.com/d1dcealocdmy) on it and found the opposite is true, didn't check in IE, but all modern browsers show varying degrees of speed increase by using the indexOf checks, chrome being the most dramatic.  Anyway, figured I'd submit a PR.